### PR TITLE
Run tests on multiple python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 jobs:
-  tests-and-lint:
+  lint:
     name: python
     runs-on: ubuntu-latest
 
@@ -27,6 +27,31 @@ jobs:
         run: |
           # Fail on any lint errors
           uv run ruff check .
-      
+  test:
+    name: python
+    needs: lint
+    runs-on: ubuntu-latest
+    strategy:
+        fail-fast: false
+        matrix:
+            python-version:
+                - '3.9'
+                - '3.11'
+                - '3.13'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
+
       - name: Run tests
         run: uv run pytest tests -vv -s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lint:
-    name: python
+    name: lint
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +28,7 @@ jobs:
           # Fail on any lint errors
           uv run ruff check .
   test:
-    name: python
+    name: test
     needs: lint
     runs-on: ubuntu-latest
     strategy:
@@ -45,7 +45,7 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v5
         with:
-          python-version-file: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
The `classifiers` in `pyproject.toml` list that this package is compatible with python 3.9, 3.11 and 3.13. But in the `Test` pipeline only python 3.13 is used. This PR splits the pipeline into two jobs; `lint` runs the linter while `test` runs `pytest` across a matrix of supported python versions.