### PR TITLE
docs: fix CLI flag names in README (--manifest, --catalog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ colibri generate [OPTIONS]
 ```
 
 **Options:**
-- `--manifest-path`: Path to dbt manifest.json (default: `target/manifest.json`)
-- `--catalog-path`: Path to dbt catalog.json (default: `target/catalog.json`)
+- `--manifest`: Path to dbt manifest.json (default: `target/manifest.json`)
+- `--catalog`: Path to dbt catalog.json (default: `target/catalog.json`)
 - `--output-dir`: Output directory (default: `dist/`)
 - `--help`: Show help message
 - `--light`: For very big dbt projects, excludes attributes like compiled SQL and returns smaller HTML file.


### PR DESCRIPTION
## Summary
Fixes incorrect CLI flag names in the README documentation for the `colibri generate` command.

## Problem
The README documentation shows outdated flag names (`--manifest-path`, `--catalog-path`) that don't exist in the actual CLI, causing errors when users copy the examples. This leads to the error:
'Error: No such option: --manifest-path Did you mean --manifest?'

## Changes
- Updated `--manifest-path` → `--manifest` in README.md
- Updated `--catalog-path` → `--catalog` in README.md

## Reasoning
Based on the actual CLI code in `src/dbt_colibri/cli/cli.py`, the correct flags are `--manifest` and `--catalog`. The README needs to reflect the actual implementation to prevent user confusion and errors.

## Testing
Verified against the CLI source code and tested with:
```bash
colibri generate --help

This change improves clarity and consistency between the documentation and actual CLI behavior, preventing user errors when following the documentation examples.


This merged version:
- Removes redundancy
- Adds the actual error message users encounter (more helpful)
- Maintains all key information (what, why, how)
- Flows logically: Problem → Solution → Verification
- Keeps it concise and professional