### PR TITLE
fix: logic error in path tree sort generator

### DIFF
--- a/src/dbt_colibri/report/generator.py
+++ b/src/dbt_colibri/report/generator.py
@@ -499,7 +499,7 @@ class DbtColibriReportGenerator:
 
             # Rebuild dict with sorted folder keys first, then __items__ last
             sorted_folder = {}
-            for key in sorted(k for k in folder.keys() if key != "__items__"):
+            for key in sorted(k for k in folder.keys() if k != "__items__"):
                 sorted_folder[key] = folder[key]
             if "__items__" in folder:
                 sorted_folder["__items__"] = folder["__items__"]


### PR DESCRIPTION
This fixes a variable scoping bug where subfolders were dropped from the byPath tree if the last key iterated adjacent to them was '__items__'. Also adds regression tests.