### PR TITLE
Add version check feature to notify users of updates

### DIFF
--- a/src/dbt_colibri/cli/cli.py
+++ b/src/dbt_colibri/cli/cli.py
@@ -40,10 +40,15 @@ except PackageNotFoundError:
 @click.group()
 @click.version_option(__version__, prog_name="dbt-colibri")
 def cli():
+    """dbt-colibri CLI tool"""
     click.echo(f"{COLIBRI_LOGO}\n")
     click.echo("Welcome to dbt-colibri 🐦")
-    """dbt-colibri CLI tool"""
-    pass
+
+    from ..utils.version_check import get_update_message
+
+    update_msg = get_update_message(__version__)
+    if update_msg:
+        click.echo(click.style(update_msg, fg="yellow"))
 
 @cli.command("generate")
 @click.option(

--- a/src/dbt_colibri/utils/version_check.py
+++ b/src/dbt_colibri/utils/version_check.py
@@ -1,0 +1,92 @@
+# src/dbt_colibri/utils/version_check.py
+
+import json
+import os
+import time
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+PYPI_URL = "https://pypi.org/pypi/dbt-colibri/json"
+CACHE_DIR = Path.home() / ".dbt-colibri"
+CACHE_FILE = CACHE_DIR / "version_check.json"
+CHECK_INTERVAL_SECONDS = 24 * 60 * 60  # 24 hours
+REQUEST_TIMEOUT_SECONDS = 2
+
+
+def _is_version_check_disabled() -> bool:
+    return os.environ.get("DBT_COLIBRI_NO_VERSION_CHECK", "").strip() == "1"
+
+
+def _read_cache() -> Optional[dict]:
+    try:
+        if CACHE_FILE.exists():
+            data = json.loads(CACHE_FILE.read_text())
+            if time.time() - data.get("timestamp", 0) < CHECK_INTERVAL_SECONDS:
+                return data
+    except Exception:
+        pass
+    return None
+
+
+def _write_cache(latest_version: str) -> None:
+    try:
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        CACHE_FILE.write_text(
+            json.dumps({"timestamp": time.time(), "latest_version": latest_version})
+        )
+    except Exception:
+        pass
+
+
+def _fetch_latest_version() -> Optional[str]:
+    try:
+        from urllib.request import urlopen, Request
+
+        req = Request(PYPI_URL, headers={"Accept": "application/json"})
+        with urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as resp:
+            data = json.loads(resp.read())
+            return data["info"]["version"]
+    except Exception:
+        return None
+
+
+def _parse_version(v: str) -> tuple:
+    """Parse a PEP 440-ish version string into a comparable tuple."""
+    try:
+        return tuple(int(x) for x in v.split("."))
+    except (ValueError, AttributeError):
+        return (0,)
+
+
+def get_update_message(current_version: str) -> Optional[str]:
+    """Check if a newer version is available and return an update message, or None."""
+    if _is_version_check_disabled():
+        return None
+
+    if current_version == "unknown":
+        return None
+
+    # Try cache first
+    cache = _read_cache()
+    if cache:
+        latest_version = cache["latest_version"]
+    else:
+        latest_version = _fetch_latest_version()
+        if latest_version:
+            _write_cache(latest_version)
+
+    if not latest_version:
+        return None
+
+    if _parse_version(latest_version) > _parse_version(current_version):
+        return (
+            f"\n╭───────────────────────────────────────────────────╮\n"
+            f"│  Update available: {current_version} → {latest_version:<28s}│\n"
+            f"│  Run `pip install -U dbt-colibri` to update       │\n"
+            f"╰───────────────────────────────────────────────────╯"
+        )
+
+    return None

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -1,0 +1,98 @@
+import json
+import time
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from dbt_colibri.utils.version_check import (
+    get_update_message,
+    _read_cache,
+    _write_cache,
+    _parse_version,
+    _is_version_check_disabled,
+)
+
+
+class TestParseVersion:
+    def test_simple(self):
+        assert _parse_version("0.3.0") == (0, 3, 0)
+
+    def test_comparison(self):
+        assert _parse_version("0.4.0") > _parse_version("0.3.0")
+        assert _parse_version("1.0.0") > _parse_version("0.99.99")
+
+    def test_invalid(self):
+        assert _parse_version("unknown") == (0,)
+
+
+class TestIsVersionCheckDisabled:
+    def test_disabled_via_env(self, monkeypatch):
+        monkeypatch.setenv("DBT_COLIBRI_NO_VERSION_CHECK", "1")
+        assert _is_version_check_disabled() is True
+
+    def test_not_disabled(self, monkeypatch):
+        monkeypatch.delenv("DBT_COLIBRI_NO_VERSION_CHECK", raising=False)
+        assert _is_version_check_disabled() is False
+
+
+class TestCache:
+    def test_write_and_read(self, tmp_path):
+        cache_file = tmp_path / "version_check.json"
+        with patch("dbt_colibri.utils.version_check.CACHE_FILE", cache_file), \
+             patch("dbt_colibri.utils.version_check.CACHE_DIR", tmp_path):
+            _write_cache("0.5.0")
+            cache = _read_cache()
+            assert cache is not None
+            assert cache["latest_version"] == "0.5.0"
+
+    def test_expired_cache(self, tmp_path):
+        cache_file = tmp_path / "version_check.json"
+        cache_file.write_text(json.dumps({
+            "timestamp": time.time() - 100_000,
+            "latest_version": "0.5.0",
+        }))
+        with patch("dbt_colibri.utils.version_check.CACHE_FILE", cache_file):
+            assert _read_cache() is None
+
+
+class TestGetUpdateMessage:
+    def test_returns_none_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("DBT_COLIBRI_NO_VERSION_CHECK", "1")
+        assert get_update_message("0.3.0") is None
+
+    def test_returns_none_for_unknown_version(self, monkeypatch):
+        monkeypatch.delenv("DBT_COLIBRI_NO_VERSION_CHECK", raising=False)
+        assert get_update_message("unknown") is None
+
+    def test_returns_message_when_outdated(self, monkeypatch):
+        monkeypatch.delenv("DBT_COLIBRI_NO_VERSION_CHECK", raising=False)
+        with patch("dbt_colibri.utils.version_check._read_cache", return_value=None), \
+             patch("dbt_colibri.utils.version_check._fetch_latest_version", return_value="0.5.0"), \
+             patch("dbt_colibri.utils.version_check._write_cache"):
+            msg = get_update_message("0.3.0")
+            assert msg is not None
+            assert "0.3.0" in msg
+            assert "0.5.0" in msg
+            assert "pip install -U dbt-colibri" in msg
+
+    def test_returns_none_when_up_to_date(self, monkeypatch):
+        monkeypatch.delenv("DBT_COLIBRI_NO_VERSION_CHECK", raising=False)
+        with patch("dbt_colibri.utils.version_check._read_cache", return_value=None), \
+             patch("dbt_colibri.utils.version_check._fetch_latest_version", return_value="0.3.0"), \
+             patch("dbt_colibri.utils.version_check._write_cache"):
+            assert get_update_message("0.3.0") is None
+
+    def test_returns_none_when_pypi_unreachable(self, monkeypatch):
+        monkeypatch.delenv("DBT_COLIBRI_NO_VERSION_CHECK", raising=False)
+        with patch("dbt_colibri.utils.version_check._read_cache", return_value=None), \
+             patch("dbt_colibri.utils.version_check._fetch_latest_version", return_value=None):
+            assert get_update_message("0.3.0") is None
+
+    def test_uses_cache(self, monkeypatch):
+        monkeypatch.delenv("DBT_COLIBRI_NO_VERSION_CHECK", raising=False)
+        cache = {"timestamp": time.time(), "latest_version": "0.6.0"}
+        with patch("dbt_colibri.utils.version_check._read_cache", return_value=cache), \
+             patch("dbt_colibri.utils.version_check._fetch_latest_version") as mock_fetch:
+            msg = get_update_message("0.3.0")
+            assert "0.6.0" in msg
+            mock_fetch.assert_not_called()

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -1,8 +1,7 @@
 import json
 import time
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
-import pytest
 
 from dbt_colibri.utils.version_check import (
     get_update_message,


### PR DESCRIPTION
## Summary
This PR adds a version check feature that notifies users when a newer version of dbt-colibri is available. The check runs when the CLI is invoked and displays a formatted message with upgrade instructions if an update is available.

## Key Changes
- **New module**: `src/dbt_colibri/utils/version_check.py` implements the version checking logic:
  - `get_update_message()`: Main function that checks for updates and returns a formatted message if a newer version is available
  - `_fetch_latest_version()`: Fetches the latest version from PyPI with a 2-second timeout
  - `_parse_version()`: Parses version strings into comparable tuples for version comparison
  - `_read_cache()` / `_write_cache()`: Caches the latest version for 24 hours to avoid repeated PyPI requests
  - `_is_version_check_disabled()`: Allows users to opt-out via `DBT_COLIBRI_NO_VERSION_CHECK=1` environment variable

- **CLI integration**: Modified `src/dbt_colibri/cli/cli.py` to call `get_update_message()` on startup and display the update notification in yellow if available

- **Comprehensive tests**: Added `tests/test_version_check.py` with 11 test cases covering:
  - Version parsing and comparison logic
  - Environment variable-based opt-out mechanism
  - Cache read/write and expiration
  - Update message generation for various scenarios (outdated, up-to-date, unreachable PyPI, cached results)

## Implementation Details
- Version checks are non-blocking with a 2-second timeout to prevent CLI slowdown
- All exceptions are silently caught to ensure the version check never breaks the CLI
- Cache is stored in `~/.dbt-colibri/version_check.json` and expires after 24 hours
- Update message is displayed in a formatted box with upgrade instructions
