### PR TITLE
Preserve quoted column casing in lineage across all dialects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-colibri"
-version = "0.3.0"
+version = "0.3.1b1"
 description = "A column lineage parser and dashboarding tool"
 authors = [
     { name="bned" }

--- a/scripts/preview_ui.py
+++ b/scripts/preview_ui.py
@@ -22,7 +22,7 @@ for version in versions:
         catalog_path=catalog_path
     )
 
-    report_generator = DbtColibriReportGenerator(extractor)
+    report_generator = DbtColibriReportGenerator(extractor, disable_telemetry=True)
     report_generator.generate_report(output_dir=output_dir)
 
     print(f"✔ Done with {version}, results in {output_dir}")

--- a/src/dbt_colibri/lineage_extractor/extractor.py
+++ b/src/dbt_colibri/lineage_extractor/extractor.py
@@ -8,6 +8,20 @@ from importlib.metadata import version, PackageNotFoundError
 import gc
 
 
+def _normalize_column_name(name: str) -> str:
+    """Normalize a column name for lineage resolution.
+
+    - Strips surrounding single/double quotes.
+    - Removes PostgreSQL-style type casts (``::type``).
+    - Strips leading ``$`` (Snowflake session variable prefix).
+    """
+    name = name.strip('"').strip("'")
+    name = re.sub(r"::\s*\w+$", "", name)
+    if name.startswith("$"):
+        name = name[1:]
+    return name
+
+
 def get_select_expressions(expr: exp.Expression) -> list[exp.Expression]:
     if isinstance(expr, exp.Select):
         return expr.expressions
@@ -101,13 +115,25 @@ class DbtColumnLineageExtractor:
         except PackageNotFoundError:
             return "unknown"
         
+    # Dialects where ``quote: true`` means the identifier is case-sensitive.
+    _CASE_SENSITIVE_QUOTE_DIALECTS = frozenset({
+        "snowflake", "postgres", "oracle", "clickhouse",
+    })
+
     def _build_quoted_columns_lookup(self):
         """Build a lookup of quoted columns (quote=True) across all manifest nodes.
 
         Returns a dict of ``{node_id: {lower_col_name: original_col_name}}``
         so that downstream code can preserve the original casing for columns
         explicitly marked as quoted in the dbt manifest.
+
+        Only populated for dialects where quoting is case-sensitive (e.g.
+        Snowflake, Postgres, Oracle, ClickHouse).  On case-insensitive
+        dialects (BigQuery, DuckDB, etc.) quoting is used to escape reserved
+        words but does not affect casing, so the lookup stays empty.
         """
+        if self.dialect not in self._CASE_SENSITIVE_QUOTE_DIALECTS:
+            return {}
         lookup = {}
         for node_id, node_data in {**self.manifest.get("nodes", {}), **self.manifest.get("sources", {})}.items():
             columns = node_data.get("columns")
@@ -336,26 +362,31 @@ class DbtColumnLineageExtractor:
 
         return sql
 
+    @staticmethod
+    def _schema_has_quoted_keys(schema):
+        """Return True if any column key in *schema* is double-quote-wrapped."""
+        for db in schema.values():
+            for sch in db.values():
+                for tbl in sch.values():
+                    if any(k.startswith('"') for k in tbl):
+                        return True
+        return False
+
     def _extract_lineage_for_model(self, model_sql, schema, model_node, resource_type, selected_columns=[]):
         lineage_map = {}
         model_sql_for_parse = self._sanitize_sql_for_parsing(model_sql)
         parsed_model_sql = maybe_parse(model_sql_for_parse, dialect=self.dialect)
         # sqlglot does not unfold * to schema when the schema has quotes, or upper (for BigQuery)
-        if self.dialect == "postgres":
+        # Skip remove_quotes when the schema contains quoted column keys, as
+        # stripping AST quotes prevents SQLGlot from matching case-sensitive columns.
+        if self.dialect == "postgres" and not self._schema_has_quoted_keys(schema):
             parsed_model_sql = parsing_utils.remove_quotes(parsed_model_sql)
         if self.dialect == "bigquery":
             parsed_model_sql = parsing_utils.remove_upper(parsed_model_sql)
         qualified_expr, scope = prepare_scope(parsed_model_sql, schema=schema, dialect=self.dialect)
-        def normalize_column_name(name: str) -> str:
-            name = name.strip('"').strip("'")
-            # Remove type casts like '::date' or '::timestamp'
-            name = re.sub(r"::\s*\w+$", "", name)
-            if name.startswith("$"):
-                name = name[1:]
-            return name
 
         for column_name in selected_columns:
-            normalized_column = normalize_column_name(column_name)
+            normalized_column = _normalize_column_name(column_name)
             if resource_type == "snapshot" and column_name in ["dbt_valid_from", "dbt_valid_to", "dbt_updated_at", "dbt_scd_id"]:
                 self.logger.debug(f"Skipping special snapshot column {column_name}")
                 lineage_map[column_name] = []
@@ -590,9 +621,32 @@ class DbtColumnLineageExtractor:
 
 
     @staticmethod
+    def _ci_get(mapping, key):
+        """Case-insensitive dict key lookup. Return the value if *key* (lowered)
+        matches any key in *mapping*, otherwise ``None``."""
+        if key in mapping:
+            return mapping[key]
+        key_lower = key.lower()
+        for k, v in mapping.items():
+            if k.lower() == key_lower:
+                return v
+        return None
+
+    @staticmethod
+    def _ci_key(mapping, key):
+        """Return the actual key in *mapping* that matches *key* case-insensitively,
+        or *key* itself if not found."""
+        if key in mapping:
+            return key
+        key_lower = key.lower()
+        for k in mapping:
+            if k.lower() == key_lower:
+                return k
+        return key
+
+    @staticmethod
     def find_all_related(lineage_map, model_node, column, visited=None):
         """Find all related columns in lineage_map that connect to model_node.column."""
-        column = column.lower()
         model_node = model_node.lower()
         if visited is None:
             visited = set()
@@ -600,20 +654,22 @@ class DbtColumnLineageExtractor:
         related = {}
 
         # Check if the model_node exists in lineage_map
-        if model_node not in lineage_map:
+        model_entry = DbtColumnLineageExtractor._ci_get(lineage_map, model_node)
+        if model_entry is None:
             return related
 
-        # Check if the column exists in the model_node
-        if column not in lineage_map[model_node]:
+        # Case-insensitive column lookup to support quoted (mixed-case) keys
+        column_key = DbtColumnLineageExtractor._ci_key(model_entry, column)
+        if column_key not in model_entry:
             return related
 
         # Process each related node
-        for related_node in lineage_map[model_node][column]:
+        for related_node in model_entry[column_key]:
             related_model = related_node["dbt_node"].lower()
-            related_column = related_node["column"].lower()
+            related_column = related_node["column"]
 
-            if (related_model, related_column) not in visited:
-                visited.add((related_model, related_column))
+            if (related_model, related_column.lower()) not in visited:
+                visited.add((related_model, related_column.lower()))
 
                 if related_model not in related:
                     related[related_model] = []
@@ -641,27 +697,28 @@ class DbtColumnLineageExtractor:
     def find_all_related_with_structure(lineage_map, model_node, column, visited=None):
         """Find all related columns with hierarchical structure."""
         model_node = model_node.lower()
-        column = column.lower()
         if visited is None:
             visited = set()
 
         # Initialize the related structure for the current node and column.
         related_structure = {}
 
-        # Return empty if model or column doesn't exist
-        if model_node not in lineage_map:
+        # Case-insensitive lookup for model and column
+        model_entry = DbtColumnLineageExtractor._ci_get(lineage_map, model_node)
+        if model_entry is None:
             return related_structure
 
-        if column not in lineage_map[model_node]:
+        column_key = DbtColumnLineageExtractor._ci_key(model_entry, column)
+        if column_key not in model_entry:
             return related_structure
 
         # Process each related node
-        for related_node in lineage_map[model_node][column]:
+        for related_node in model_entry[column_key]:
             related_model = related_node["dbt_node"].lower()
-            related_column = related_node["column"].lower()
+            related_column = related_node["column"]
 
-            if (related_model, related_column) not in visited:
-                visited.add((related_model, related_column))
+            if (related_model, related_column.lower()) not in visited:
+                visited.add((related_model, related_column.lower()))
 
                 # Recursively get the structure for each related node
                 subsequent_structure = DbtColumnLineageExtractor.find_all_related_with_structure(
@@ -732,19 +789,11 @@ class DbtColumnLineageExtractor:
                 # Parse and qualify once per model
                 model_sql_for_parse = self._sanitize_sql_for_parsing(model_sql)
                 parsed_model_sql = maybe_parse(model_sql_for_parse, dialect=self.dialect)
-                if self.dialect == "postgres":
+                if self.dialect == "postgres" and not self._schema_has_quoted_keys(schema):
                     parsed_model_sql = parsing_utils.remove_quotes(parsed_model_sql)
                 if self.dialect == "bigquery":
                     parsed_model_sql = parsing_utils.remove_upper(parsed_model_sql)
                 qualified_expr, scope = prepare_scope(parsed_model_sql, schema=schema, dialect=self.dialect)
-
-                def normalize_column_name(name: str) -> str:
-                    name = name.strip('"').strip("'")
-                    name = re.sub(r"::\s*\w+$", "", name)
-                    if name.startswith("$"):
-                        name = name[1:]
-                        
-                    return name
 
                 # Initialize parents entry for this model
                 model_parents: dict = {}
@@ -784,7 +833,7 @@ class DbtColumnLineageExtractor:
                         )
 
                     try:
-                        normalized_column = normalize_column_name(column_name)
+                        normalized_column = _normalize_column_name(column_name)
                         lineage_node = lineage(
                             normalized_column,
                             qualified_expr,
@@ -809,7 +858,7 @@ class DbtColumnLineageExtractor:
                                 alias = expr.alias_or_name
                                 if alias:
                                     alias_expr_map[alias.lower()] = expr
-                            expr = alias_expr_map.get(normalize_column_name(column_name).lower())
+                            expr = alias_expr_map.get(_normalize_column_name(column_name).lower())
                             self.logger.debug(f"Available aliases in query: {list(alias_expr_map.keys())}")
                             if expr:
                                 upstream_columns = extract_column_refs(expr)
@@ -860,7 +909,7 @@ class DbtColumnLineageExtractor:
                                             entries.append(parent_columns)
                                             # Update children map
                                             parent_model = parent_columns["dbt_node"]
-                                            parent_col = parent_columns["column"].lower()
+                                            parent_col = parent_columns["column"]
                                             children.setdefault(parent_model, {}).setdefault(parent_col, []).append(
                                                 {"column": key, "dbt_node": model_node}
                                             )

--- a/src/dbt_colibri/lineage_extractor/extractor.py
+++ b/src/dbt_colibri/lineage_extractor/extractor.py
@@ -35,6 +35,7 @@ class DbtColumnLineageExtractor:
         self.schema_dict = self._generate_schema_dict_from_catalog()
         self.dialect = self._detect_adapter_type()
         # self.node_mapping = self._get_dict_mapping_full_table_name_to_dbt_node()
+        self._quoted_columns_lookup = self._build_quoted_columns_lookup()
         self.nodes_with_columns = self.build_nodes_with_columns()
         self._table_to_node = {k.lower(): v for k, v in self.nodes_with_columns.items()}
         # Store references to parent and child maps for easy access
@@ -100,6 +101,45 @@ class DbtColumnLineageExtractor:
         except PackageNotFoundError:
             return "unknown"
         
+    def _build_quoted_columns_lookup(self):
+        """Build a lookup of quoted columns (quote=True) across all manifest nodes.
+
+        Returns a dict of ``{node_id: {lower_col_name: original_col_name}}``
+        so that downstream code can preserve the original casing for columns
+        explicitly marked as quoted in the dbt manifest.
+        """
+        lookup = {}
+        for node_id, node_data in {**self.manifest.get("nodes", {}), **self.manifest.get("sources", {})}.items():
+            columns = node_data.get("columns")
+            if not columns:
+                continue
+            quoted = {}
+            for col_name, col_info in columns.items():
+                if col_info.get("quote") is True:
+                    quoted[col_name.lower()] = col_name
+            if quoted:
+                lookup[node_id] = quoted
+        return lookup
+
+    def _get_quoted_columns(self, node_id):
+        """Return ``{lower_col_name: original_col_name}`` for quoted columns of *node_id*."""
+        lookup = getattr(self, "_quoted_columns_lookup", None)
+        if lookup is None:
+            return {}
+        return lookup.get(node_id, {})
+
+    def _resolve_column_name(self, column_name, node_id):
+        """Return the properly-cased column name.
+
+        For columns with ``quote: true`` in the manifest, the original casing
+        is preserved.  All other columns are lowercased for consistency.
+        """
+        col_lower = column_name.lower()
+        quoted = self._get_quoted_columns(node_id)
+        if col_lower in quoted:
+            return quoted[col_lower]
+        return col_lower
+
     def _detect_adapter_type(self):
         """
         Detect the adapter type from the manifest metadata.
@@ -248,7 +288,7 @@ class DbtColumnLineageExtractor:
         else:
             self.logger.warning(f"Node {node} not found in catalog, maybe it's not materialized")
             return []
-        return [col.lower() for col in list(columns.keys())]
+        return [self._resolve_column_name(col, node) for col in columns.keys()]
 
     def _get_parent_nodes_catalog(self, model_info):
         parent_nodes = model_info["depends_on"]["nodes"]
@@ -437,11 +477,11 @@ class DbtColumnLineageExtractor:
     def get_dbt_node_from_sqlglot_table_node(self, node, model_node):
         if node.source.key != "table":
             raise ValueError(f"Node source is not a table, but {node.source.key}")
-        
+
         if not node.source.catalog and not node.source.db:
             return None
-            
-        column_name = node.name.split(".")[-1].lower()
+
+        column_name_raw = node.name.split(".")[-1]
 
         if self.dialect == 'clickhouse':
             table_name = f"{node.source.db}.{node.source.name}"
@@ -449,7 +489,7 @@ class DbtColumnLineageExtractor:
             table_name = self._table_key_from_sqlglot_table_node(node)
         else:
             table_name = f"{node.source.catalog}.{node.source.db}.{node.source.name}"
-        
+
         match = self._table_to_node.get(table_name.lower())
         if match:
             dbt_node = match["unique_id"]
@@ -480,6 +520,9 @@ class DbtColumnLineageExtractor:
                 dbt_node = f"_NOT_FOUND___{table_name.lower()}"
             # raise ValueError(f"Table {table_name} not found in node mapping")
 
+        # Preserve original case for quoted columns in the parent node
+        column_name = self._resolve_column_name(column_name_raw, dbt_node)
+
         return {"column": column_name, "dbt_node": dbt_node}
 
     def get_columns_lineage_from_sqlglot_lineage_map(self, lineage_map, picked_columns=[]):
@@ -499,7 +542,7 @@ class DbtColumnLineageExtractor:
                 columns_lineage[model_node_lower] = {}
 
             for column, node in columns.items():
-                column = column.lower()
+                column = self._resolve_column_name(column, model_node_lower)
                 if picked_columns and column not in picked_columns:
                     continue
 
@@ -689,8 +732,12 @@ class DbtColumnLineageExtractor:
 
                 columns = self._get_list_of_columns_for_a_dbt_node(model_node)
 
+                quoted_cols = self._get_quoted_columns(model_node)
+
                 for column_name in columns:
-                    column_key = column_name.lower()
+                    # Preserve original casing for quoted columns
+                    col_lower = column_name.lower()
+                    column_key = quoted_cols[col_lower] if col_lower in quoted_cols else col_lower
                     # Snapshot special columns
                     if model_info.get("resource_type") == "snapshot" and column_name in [
                         "dbt_valid_from",
@@ -706,7 +753,7 @@ class DbtColumnLineageExtractor:
 
                     def append_parent(parent_columns, lineage_type, _model_parents=model_parents, _column_key=column_key):
                         parent_model = parent_columns["dbt_node"]
-                        parent_col = parent_columns["column"].lower()
+                        parent_col = parent_columns["column"]
                         if parent_model == model_node:
                             return
                         if parent_columns not in _model_parents[_column_key]:

--- a/src/dbt_colibri/lineage_extractor/extractor.py
+++ b/src/dbt_colibri/lineage_extractor/extractor.py
@@ -133,8 +133,12 @@ class DbtColumnLineageExtractor:
 
         For columns with ``quote: true`` in the manifest, the original casing
         is preserved.  All other columns are lowercased for consistency.
+        Handles column names that may arrive with surrounding double-quotes
+        from SQLGlot (e.g. ``'"quotedCol"'``).
         """
-        col_lower = column_name.lower()
+        # Strip surrounding double-quotes that SQLGlot may add
+        stripped = column_name.strip('"')
+        col_lower = stripped.lower()
         quoted = self._get_quoted_columns(node_id)
         if col_lower in quoted:
             return quoted[col_lower]
@@ -252,7 +256,22 @@ class DbtColumnLineageExtractor:
             if table_name not in schema_dict[db_name][schema_name]:
                 schema_dict[db_name][schema_name][table_name] = {}
 
-            schema_dict[db_name][schema_name][table_name].update(dbt_node.get_column_types())
+            col_types = dbt_node.get_column_types()
+
+            # For columns with quote=True in the manifest, wrap the key in
+            # double-quotes so SQLGlot's qualifier can match quoted identifiers.
+            quoted_cols = self._get_quoted_columns(dbt_node.unique_id)
+            if quoted_cols:
+                wrapped = {}
+                for col_name, col_type in col_types.items():
+                    if col_name.lower() in quoted_cols:
+                        original = quoted_cols[col_name.lower()]
+                        wrapped[f'"{original}"'] = col_type
+                    else:
+                        wrapped[col_name] = col_type
+                col_types = wrapped
+
+            schema_dict[db_name][schema_name][table_name].update(col_types)
 
         for node in catalog.get("nodes", {}).values():
             add_to_schema_dict(node)

--- a/src/dbt_colibri/report/generator.py
+++ b/src/dbt_colibri/report/generator.py
@@ -55,9 +55,12 @@ class DbtColibriReportGenerator:
             if not attached_node:
                 continue
 
-            # Extract the column name (lowercase for consistency)
+            # Extract the column name, preserving case for quoted columns
             column_name = node_data.get("column_name")
-            column_key = column_name.lower() if column_name else "__model__"
+            if column_name:
+                column_key = self.extractor._resolve_column_name(column_name, attached_node)
+            else:
+                column_key = "__model__"
 
             # Extract test metadata
             test_metadata = node_data.get("test_metadata", {})
@@ -161,6 +164,8 @@ class DbtColibriReportGenerator:
         # enriching with manifest metadata when available.
         columns = {}
         manifest_columns = {}
+        # Build a lookup of quoted columns (quote=True) -> original name
+        quoted_cols = {}
         if node_data and node_data.get("columns"):
             for col, val in node_data["columns"].items():
                 col_meta = {
@@ -170,10 +175,15 @@ class DbtColibriReportGenerator:
                 col_tags = val.get("tags", [])
                 if col_tags:
                     col_meta["tags"] = col_tags
+                if val.get("quote") is True:
+                    col_meta["quote"] = True
+                    quoted_cols[col.lower()] = col
                 manifest_columns[col.lower()] = col_meta
         if catalog_data and catalog_data.get("columns"):
             for col, val in catalog_data["columns"].items():
                 col_lc = col.lower()
+                # Preserve original case for quoted columns
+                col_key = quoted_cols.get(col_lc, col_lc)
                 entry = {"dataType": val.get("type")}
                 if col_lc in manifest_columns:
                     if manifest_columns[col_lc].get("contractType") is not None:
@@ -182,7 +192,9 @@ class DbtColibriReportGenerator:
                         entry["description"] = manifest_columns[col_lc]["description"]
                     if manifest_columns[col_lc].get("tags"):
                         entry["tags"] = manifest_columns[col_lc]["tags"]
-                columns[col_lc] = entry
+                    if manifest_columns[col_lc].get("quote"):
+                        entry["quote"] = True
+                columns[col_key] = entry
 
         node_type = node_data.get("resource_type", "unknown")
         materialized = (node_data.get("config") or {}).get("materialized", "unknown")

--- a/tests/dbt_test_factory.py
+++ b/tests/dbt_test_factory.py
@@ -1,0 +1,323 @@
+"""
+Lightweight factory for generating synthetic dbt manifest + catalog test data
+across all supported dialects, without requiring dbt-core.
+
+Uses SQLGlot's dialect awareness to produce correctly-cased identifiers so
+that tests exercise the same code paths as real dbt artifacts would.
+
+Dialect conventions (as observed via SQLGlot):
+  - Snowflake / Oracle:  unquoted → UPPERCASE, quoted → preserves case
+  - Postgres / Redshift / Trino / DuckDB / BigQuery / ClickHouse / TSQL / Databricks:
+                          unquoted → lowercase, quoted → see below
+
+Quoted column case-sensitivity (SQLGlot qualify behaviour):
+  Preserves case: snowflake, postgres, oracle, clickhouse
+  Lowercases:     bigquery, duckdb, redshift, trino, tsql, databricks
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from typing import Optional
+from unittest.mock import patch
+
+import sqlglot
+
+
+# ---------------------------------------------------------------------------
+# Dialect metadata
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class DialectInfo:
+    """How a SQL dialect treats identifiers."""
+    name: str
+    # "upper" or "lower" – how unquoted identifiers appear in the catalog.
+    unquoted_case: str
+    # Whether the dialect preserves original casing for quoted identifiers.
+    quoted_preserves_case: bool
+    # The adapter_type value written into the dbt manifest metadata.
+    adapter_type: str
+    # If the adapter_type differs from the SQLGlot dialect name.
+    sqlglot_dialect: Optional[str] = None
+
+
+DIALECTS: dict[str, DialectInfo] = {
+    "snowflake": DialectInfo("snowflake", "upper", True, "snowflake"),
+    "postgres": DialectInfo("postgres", "lower", True, "postgres"),
+    "oracle": DialectInfo("oracle", "upper", True, "oracle"),
+    "clickhouse": DialectInfo("clickhouse", "lower", True, "clickhouse"),
+    "bigquery": DialectInfo("bigquery", "lower", False, "bigquery"),
+    "duckdb": DialectInfo("duckdb", "lower", False, "duckdb"),
+    "redshift": DialectInfo("redshift", "lower", False, "redshift"),
+    "trino": DialectInfo("trino", "lower", False, "trino"),
+    "tsql": DialectInfo("tsql", "lower", False, "sqlserver", sqlglot_dialect="tsql"),
+    "databricks": DialectInfo("databricks", "lower", False, "databricks"),
+}
+
+# Dialects where ``quote: true`` in dbt meaningfully preserves casing.
+CASE_SENSITIVE_QUOTE_DIALECTS = frozenset(
+    name for name, info in DIALECTS.items() if info.quoted_preserves_case
+)
+
+
+# ---------------------------------------------------------------------------
+# Column definition
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ColumnDef:
+    """Describes a column in both manifest and catalog."""
+    name: str
+    data_type: str = "VARCHAR"
+    quote: bool = False
+    description: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Helper: apply dialect casing rules
+# ---------------------------------------------------------------------------
+
+def catalog_column_name(col: ColumnDef, dialect_info: DialectInfo) -> str:
+    """Return the column name as it would appear in a catalog for *dialect_info*.
+
+    - Unquoted columns follow the dialect's default casing rule.
+    - Quoted columns preserve their original name on case-sensitive dialects,
+      and are lowercased on case-insensitive dialects.
+    """
+    if col.quote and dialect_info.quoted_preserves_case:
+        return col.name  # e.g. "quotedCol" stays as-is on Snowflake
+    if dialect_info.unquoted_case == "upper":
+        return col.name.upper()
+    return col.name.lower()
+
+
+def catalog_table_name(name: str, dialect_info: DialectInfo) -> str:
+    """Return a table/schema/database name as it appears in the catalog."""
+    if dialect_info.unquoted_case == "upper":
+        return name.upper()
+    return name.lower()
+
+
+def compiled_column_ref(col: ColumnDef, dialect_info: DialectInfo) -> str:
+    """Return the column reference as it would appear in compiled SQL."""
+    if col.quote:
+        if dialect_info.name == "bigquery":
+            return f"`{col.name}`"
+        elif dialect_info.name == "tsql":
+            return f"[{col.name}]"
+        else:
+            return f'"{col.name}"'
+    # Unquoted — use dialect casing
+    if dialect_info.unquoted_case == "upper":
+        return col.name.upper()
+    return col.name.lower()
+
+
+# ---------------------------------------------------------------------------
+# Factory: build manifest + catalog dicts
+# ---------------------------------------------------------------------------
+
+def build_test_artifacts(
+    dialect: str,
+    source_columns: list[ColumnDef],
+    model_columns: Optional[list[ColumnDef]] = None,
+    *,
+    project_name: str = "test_project",
+    source_name: str = "raw",
+    source_table: str = "source_table",
+    model_name: str = "my_model",
+    database: str = "test_db",
+    source_schema: str = "raw_schema",
+    model_schema: str = "public",
+) -> tuple[dict, dict]:
+    """Build a minimal but valid manifest + catalog pair.
+
+    The model is a simple ``SELECT <columns> FROM <source_table>`` so that
+    lineage should map each model column back to the corresponding source column.
+
+    Parameters
+    ----------
+    dialect : str
+        One of the keys in ``DIALECTS``.
+    source_columns : list[ColumnDef]
+        Columns on the source (and by default, also on the model).
+    model_columns : list[ColumnDef] | None
+        Columns on the model. Defaults to *source_columns*.
+
+    Returns
+    -------
+    (manifest_dict, catalog_dict)
+    """
+    info = DIALECTS[dialect]
+    adapter_type = info.adapter_type
+    sqlglot_dialect = info.sqlglot_dialect or info.name
+
+    if model_columns is None:
+        model_columns = copy.deepcopy(source_columns)
+
+    # Catalog-cased names
+    cat_db = catalog_table_name(database, info)
+    cat_src_schema = catalog_table_name(source_schema, info)
+    cat_model_schema = catalog_table_name(model_schema, info)
+    cat_src_table = catalog_table_name(source_table, info)
+    cat_model_table = catalog_table_name(model_name, info)
+
+    # Build SQL column refs for compiled code
+    col_refs = ", ".join(compiled_column_ref(c, info) for c in model_columns)
+    if info.name == "clickhouse":
+        table_ref = f"{cat_src_schema}.{cat_src_table}"
+    elif info.name == "oracle":
+        table_ref = f"{cat_src_schema}.{cat_src_table}"
+    else:
+        table_ref = f"{cat_db}.{cat_src_schema}.{cat_src_table}"
+    compiled_sql = f"SELECT {col_refs} FROM {table_ref}"
+
+    source_id = f"source.{project_name}.{source_name}.{source_table}"
+    model_id = f"model.{project_name}.{model_name}"
+
+    # -- Manifest --------------------------------------------------------
+    def _manifest_columns(cols):
+        out = {}
+        for c in cols:
+            entry = {
+                "name": c.name,
+                "description": c.description,
+                "data_type": c.data_type,
+                "tags": [],
+            }
+            if c.quote:
+                entry["quote"] = True
+            out[c.name] = entry
+        return out
+
+    def _relation_name(db, schema, table, info):
+            """Build a dialect-appropriate relation_name."""
+            if info.name == "clickhouse":
+                s = catalog_table_name(schema, info)
+                t = catalog_table_name(table, info)
+                return f"`{s}`.`{t}`"
+            elif info.name == "bigquery":
+                d = catalog_table_name(db, info)
+                s = catalog_table_name(schema, info)
+                t = catalog_table_name(table, info)
+                return f"`{d}`.`{s}`.`{t}`"
+            elif info.name == "oracle":
+                s = catalog_table_name(schema, info)
+                t = catalog_table_name(table, info)
+                return f"{s}.{t}"
+            else:
+                d = catalog_table_name(db, info)
+                s = catalog_table_name(schema, info)
+                t = catalog_table_name(table, info)
+                return f'"{d}"."{s}"."{t}"'
+
+    manifest = {
+        "metadata": {
+            "adapter_type": adapter_type,
+            "dbt_version": "1.11.6",
+            "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+            "invocation_id": "test-fixture",
+            "project_name": project_name,
+        },
+        "nodes": {
+            model_id: {
+                "path": f"models/{model_name}.sql",
+                "original_file_path": f"models/{model_name}.sql",
+                "resource_type": "model",
+                "compiled_code": compiled_sql,
+                "raw_code": compiled_sql,
+                "depends_on": {"nodes": [source_id]},
+                "database": database,
+                "schema": model_schema,
+                "name": model_name,
+                "alias": model_name,
+                "columns": _manifest_columns(model_columns),
+                "relation_name": _relation_name(database, model_schema, model_name, info),
+                "config": {"materialized": "table"},
+                "refs": [],
+                "tags": [],
+                "fqn": [project_name, model_name],
+            },
+        },
+        "sources": {
+            source_id: {
+                "path": "models/sources.yml",
+                "original_file_path": "models/sources.yml",
+                "resource_type": "source",
+                "database": database,
+                "schema": source_schema,
+                "name": source_table,
+                "identifier": source_table,
+                "columns": _manifest_columns(source_columns),
+                "relation_name": _relation_name(database, source_schema, source_table, info),
+                "config": {"materialized": None},
+                "fqn": [project_name, source_name, source_table],
+                "tags": [],
+            },
+        },
+        "exposures": {},
+        "parent_map": {
+            model_id: [source_id],
+            source_id: [],
+        },
+        "child_map": {
+            source_id: [model_id],
+            model_id: [],
+        },
+    }
+
+    # -- Catalog ---------------------------------------------------------
+    def _catalog_columns(cols, info):
+        out = {}
+        for i, c in enumerate(cols, 1):
+            cat_name = catalog_column_name(c, info)
+            out[cat_name] = {
+                "type": c.data_type,
+                "name": cat_name,
+                "index": i,
+                "comment": None,
+            }
+        return out
+
+    catalog = {
+        "nodes": {
+            model_id: {
+                "unique_id": model_id,
+                "metadata": {
+                    "database": cat_db,
+                    "schema": cat_model_schema,
+                    "name": cat_model_table,
+                    "type": "table",
+                },
+                "columns": _catalog_columns(model_columns, info),
+            },
+        },
+        "sources": {
+            source_id: {
+                "unique_id": source_id,
+                "metadata": {
+                    "database": cat_db,
+                    "schema": cat_src_schema,
+                    "name": cat_src_table,
+                    "type": "table",
+                },
+                "columns": _catalog_columns(source_columns, info),
+            },
+        },
+    }
+
+    return manifest, catalog
+
+
+def make_extractor(dialect: str, source_columns: list[ColumnDef], **kwargs):
+    """Convenience: build artifacts and return a ready DbtColumnLineageExtractor."""
+    from dbt_colibri.lineage_extractor.extractor import DbtColumnLineageExtractor
+
+    manifest, catalog = build_test_artifacts(dialect, source_columns, **kwargs)
+    with patch("dbt_colibri.utils.json_utils.read_json") as mock:
+        mock.side_effect = [manifest, catalog]
+        return DbtColumnLineageExtractor(
+            manifest_path="dummy", catalog_path="dummy"
+        )

--- a/tests/dbt_test_factory.py
+++ b/tests/dbt_test_factory.py
@@ -18,11 +18,10 @@ Quoted column case-sensitivity (SQLGlot qualify behaviour):
 from __future__ import annotations
 
 import copy
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 from unittest.mock import patch
 
-import sqlglot
 
 
 # ---------------------------------------------------------------------------
@@ -152,7 +151,6 @@ def build_test_artifacts(
     """
     info = DIALECTS[dialect]
     adapter_type = info.adapter_type
-    sqlglot_dialect = info.sqlglot_dialect or info.name
 
     if model_columns is None:
         model_columns = copy.deepcopy(source_columns)

--- a/tests/test_case_sensitivity.py
+++ b/tests/test_case_sensitivity.py
@@ -1,5 +1,12 @@
 import pytest
 from dbt_colibri.lineage_extractor.extractor import DbtColumnLineageExtractor
+from dbt_colibri.report.generator import DbtColibriReportGenerator
+from dbt_test_factory import (
+    ColumnDef,
+    CASE_SENSITIVE_QUOTE_DIALECTS,
+    DIALECTS,
+    make_extractor,
+)
 
 def test_locations_column_lineage_case_sensitivity(dbt_valid_test_data_dir):
     """Test that model.jaffle_shop.locations has proper column lineage with correct case sensitivity."""
@@ -63,3 +70,134 @@ def test_locations_column_lineage_case_sensitivity(dbt_valid_test_data_dir):
         f"Expected 4 columns in locations lineage, but got {len(locations_lineage)}"
     
     print(f"✓ Column lineage test passed for model.jaffle_shop.locations with {len(locations_lineage)} columns")
+
+
+# ---------------------------------------------------------------------------
+# Cross-dialect quoted-column tests using the synthetic fixture factory
+# ---------------------------------------------------------------------------
+
+COLUMNS = [
+    ColumnDef("quotedMixedCase", "VARCHAR", quote=True),
+    ColumnDef("normal_col", "NUMBER"),
+]
+
+MODEL_ID = "model.test_project.my_model"
+SOURCE_ID = "source.test_project.raw.source_table"
+
+
+@pytest.mark.parametrize("dialect", sorted(CASE_SENSITIVE_QUOTE_DIALECTS))
+class TestQuotedColumnLineageByDialect:
+    """
+    Verify that quoted columns preserve casing through the entire pipeline
+    for every dialect where quoting is case-sensitive.
+    """
+
+    def test_extract_lineage_preserves_quoted_column_key(self, dialect):
+        """The parents map should use the original-case column name as the key."""
+        extractor = make_extractor(dialect, COLUMNS)
+        parents = extractor.extract_project_lineage()["lineage"]["parents"]
+
+        model_lineage = parents[MODEL_ID]
+        assert "quotedMixedCase" in model_lineage, \
+            f"[{dialect}] Expected 'quotedMixedCase' in parents, got: {list(model_lineage.keys())}"
+        assert "quotedmixedcase" not in model_lineage, \
+            f"[{dialect}] Lowercased key should not exist"
+
+    def test_extract_lineage_parent_column_preserves_case(self, dialect):
+        """The parent entry's column name should preserve original casing."""
+        extractor = make_extractor(dialect, COLUMNS)
+        parents = extractor.extract_project_lineage()["lineage"]["parents"]
+
+        entries = parents[MODEL_ID]["quotedMixedCase"]
+        assert len(entries) > 0, f"[{dialect}] No lineage for quoted column"
+        assert entries[0]["column"] == "quotedMixedCase", \
+            f"[{dialect}] Parent column should be 'quotedMixedCase', got: {entries[0]['column']!r}"
+        assert entries[0]["dbt_node"] == SOURCE_ID
+
+    def test_children_map_preserves_quoted_column_key(self, dialect):
+        """The children map entry for the source should use original-case column."""
+        extractor = make_extractor(dialect, COLUMNS)
+        children = extractor.extract_project_lineage()["lineage"]["children"]
+
+        src_children = children.get(SOURCE_ID, {})
+        assert "quotedMixedCase" in src_children, \
+            f"[{dialect}] Expected 'quotedMixedCase' in children, got: {list(src_children.keys())}"
+
+    def test_unquoted_column_still_lowercased(self, dialect):
+        """Unquoted columns should still be lowercased as before."""
+        extractor = make_extractor(dialect, COLUMNS)
+        parents = extractor.extract_project_lineage()["lineage"]["parents"]
+
+        model_lineage = parents[MODEL_ID]
+        assert "normal_col" in model_lineage, \
+            f"[{dialect}] Expected 'normal_col' in parents, got: {list(model_lineage.keys())}"
+
+    def test_report_output_preserves_quoted_columns(self, dialect):
+        """build_full_lineage output should have correct column names and quote flags."""
+        extractor = make_extractor(dialect, COLUMNS)
+        generator = DbtColibriReportGenerator(extractor)
+        result = generator.build_full_lineage()
+
+        model_node = result["nodes"][MODEL_ID]
+        assert "quotedMixedCase" in model_node["columns"], \
+            f"[{dialect}] Expected 'quotedMixedCase' in output columns, got: {list(model_node['columns'].keys())}"
+        assert model_node["columns"]["quotedMixedCase"].get("quote") is True
+        assert model_node["columns"]["quotedMixedCase"].get("hasLineage") is True
+
+    def test_report_edges_reference_correct_column_name(self, dialect):
+        """Lineage edges should use the original-case column name."""
+        extractor = make_extractor(dialect, COLUMNS)
+        generator = DbtColibriReportGenerator(extractor)
+        result = generator.build_full_lineage()
+
+        edges = [
+            e for e in result["lineage"]["edges"]
+            if e["target"] == MODEL_ID and e["targetColumn"] == "quotedMixedCase"
+        ]
+        assert len(edges) > 0, f"[{dialect}] No edge targeting 'quotedMixedCase'"
+        assert edges[0]["sourceColumn"] == "quotedMixedCase"
+
+    def test_find_all_related_with_quoted_columns(self, dialect):
+        """find_all_related should handle mixed-case keys via case-insensitive lookup."""
+        extractor = make_extractor(dialect, COLUMNS)
+        lineage_data = extractor.extract_project_lineage()
+
+        # Build a lineage_map in the format find_all_related expects
+        lineage_map = lineage_data["lineage"]["parents"]
+
+        # Should work with the exact-case column name
+        related = DbtColumnLineageExtractor.find_all_related(
+            lineage_map, MODEL_ID, "quotedMixedCase"
+        )
+        assert SOURCE_ID.lower() in related or SOURCE_ID in related, \
+            f"[{dialect}] find_all_related should trace to source, got: {related}"
+
+    def test_find_all_related_with_structure_quoted_columns(self, dialect):
+        """find_all_related_with_structure should handle mixed-case keys."""
+        extractor = make_extractor(dialect, COLUMNS)
+        lineage_map = extractor.extract_project_lineage()["lineage"]["parents"]
+
+        structure = DbtColumnLineageExtractor.find_all_related_with_structure(
+            lineage_map, MODEL_ID, "quotedMixedCase"
+        )
+        assert len(structure) > 0, \
+            f"[{dialect}] Expected non-empty structure, got: {structure}"
+
+
+@pytest.mark.parametrize("dialect", sorted(set(DIALECTS.keys()) - CASE_SENSITIVE_QUOTE_DIALECTS))
+class TestCaseInsensitiveDialects:
+    """
+    For dialects where quoting doesn't preserve case (BigQuery, DuckDB, etc.),
+    quoted columns should be lowercased like everything else.
+    """
+
+    def test_quoted_column_is_lowercased(self, dialect):
+        """On case-insensitive dialects, even quoted columns appear lowercase."""
+        extractor = make_extractor(dialect, COLUMNS)
+        parents = extractor.extract_project_lineage()["lineage"]["parents"]
+
+        model_lineage = parents.get(MODEL_ID, {})
+        # The column key should be lowercased
+        col_keys = list(model_lineage.keys())
+        assert all(k == k.lower() for k in col_keys), \
+            f"[{dialect}] All column keys should be lowercase, got: {col_keys}"

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -880,3 +880,160 @@ def test_nodes_with_null_relation_name_are_skipped():
 
         # The operation with null relation_name should NOT be present
         assert not any("on-run-end" in key for key in nodes_with_columns.keys())
+
+
+def test_quoted_columns_preserve_case():
+    """
+    Test that columns with quote=True in the manifest preserve their original
+    casing throughout the pipeline, while unquoted columns are still lowercased.
+
+    Regression test for: https://github.com/b-ned/dbt-colibri/issues/102
+    """
+    manifest = {
+        "metadata": {
+            "adapter_type": "snowflake"
+        },
+        "nodes": {
+            "model.test_project.quoted_test": {
+                "path": "models/quoted_test.sql",
+                "resource_type": "model",
+                "compiled_code": "select 'test' as \"quotedColumnExample\", 1 as normal_col",
+                "raw_code": "select 'test' as \"quotedColumnExample\", 1 as normal_col",
+                "depends_on": {"nodes": ["source.test_project.raw.raw_table"]},
+                "database": "TEST_DB",
+                "schema": "TEST_SCHEMA",
+                "name": "quoted_test",
+                "alias": "quoted_test",
+                "columns": {
+                    "quotedColumnExample": {
+                        "name": "quotedColumnExample",
+                        "description": "A quoted column",
+                        "quote": True,
+                        "data_type": "VARCHAR",
+                        "tags": []
+                    },
+                    "NORMAL_COL": {
+                        "name": "NORMAL_COL",
+                        "description": "A normal column",
+                        "data_type": "NUMBER",
+                        "tags": []
+                    }
+                },
+                "relation_name": "\"TEST_DB\".\"TEST_SCHEMA\".\"QUOTED_TEST\"",
+                "config": {"materialized": "table"}
+            }
+        },
+        "sources": {
+            "source.test_project.raw.raw_table": {
+                "path": "models/sources.yml",
+                "resource_type": "source",
+                "database": "TEST_DB",
+                "schema": "RAW",
+                "name": "raw_table",
+                "identifier": "raw_table",
+                "columns": {
+                    "quotedColumnExample": {
+                        "name": "quotedColumnExample",
+                        "description": "Source quoted column",
+                        "quote": True,
+                        "data_type": "VARCHAR",
+                        "tags": []
+                    },
+                    "NORMAL_COL": {
+                        "name": "NORMAL_COL",
+                        "description": "Source normal column",
+                        "data_type": "NUMBER",
+                        "tags": []
+                    }
+                },
+                "relation_name": "\"TEST_DB\".\"RAW\".\"RAW_TABLE\"",
+                "config": {"materialized": None}
+            }
+        },
+        "parent_map": {
+            "model.test_project.quoted_test": ["source.test_project.raw.raw_table"]
+        },
+        "child_map": {
+            "source.test_project.raw.raw_table": ["model.test_project.quoted_test"]
+        }
+    }
+
+    catalog = {
+        "nodes": {
+            "model.test_project.quoted_test": {
+                "unique_id": "model.test_project.quoted_test",
+                "metadata": {
+                    "database": "TEST_DB",
+                    "schema": "TEST_SCHEMA",
+                    "name": "QUOTED_TEST",
+                    "type": "table"
+                },
+                "columns": {
+                    "quotedColumnExample": {
+                        "type": "VARCHAR",
+                        "name": "quotedColumnExample",
+                        "index": 1,
+                        "comment": None
+                    },
+                    "NORMAL_COL": {
+                        "type": "NUMBER",
+                        "name": "NORMAL_COL",
+                        "index": 2,
+                        "comment": None
+                    }
+                }
+            }
+        },
+        "sources": {
+            "source.test_project.raw.raw_table": {
+                "unique_id": "source.test_project.raw.raw_table",
+                "metadata": {
+                    "database": "TEST_DB",
+                    "schema": "RAW",
+                    "name": "RAW_TABLE",
+                    "type": "table"
+                },
+                "columns": {
+                    "quotedColumnExample": {
+                        "type": "VARCHAR",
+                        "name": "quotedColumnExample",
+                        "index": 1,
+                        "comment": None
+                    },
+                    "NORMAL_COL": {
+                        "type": "NUMBER",
+                        "name": "NORMAL_COL",
+                        "index": 2,
+                        "comment": None
+                    }
+                }
+            }
+        }
+    }
+
+    with patch('dbt_colibri.utils.json_utils.read_json') as mock_read_json:
+        mock_read_json.side_effect = [manifest, catalog]
+
+        extractor = DbtColumnLineageExtractor(
+            manifest_path="dummy_path",
+            catalog_path="dummy_path"
+        )
+
+        # 1. Verify _get_quoted_columns returns the correct lookup
+        quoted = extractor._get_quoted_columns("model.test_project.quoted_test")
+        assert "quotedcolumnexample" in quoted
+        assert quoted["quotedcolumnexample"] == "quotedColumnExample"
+
+        # 2. Verify _resolve_column_name preserves case for quoted columns
+        assert extractor._resolve_column_name("quotedColumnExample", "model.test_project.quoted_test") == "quotedColumnExample"
+        assert extractor._resolve_column_name("QUOTEDCOLUMNEXAMPLE", "model.test_project.quoted_test") == "quotedColumnExample"
+
+        # 3. Verify _resolve_column_name lowercases non-quoted columns
+        assert extractor._resolve_column_name("NORMAL_COL", "model.test_project.quoted_test") == "normal_col"
+
+        # 4. Verify _get_list_of_columns_for_a_dbt_node preserves case for quoted columns
+        columns = extractor._get_list_of_columns_for_a_dbt_node("model.test_project.quoted_test")
+        assert "quotedColumnExample" in columns, f"Expected 'quotedColumnExample' in {columns}"
+        assert "normal_col" in columns, f"Expected 'normal_col' in {columns}"
+        # Should NOT have the lowercased version of the quoted column
+        assert "quotedcolumnexample" not in columns, f"Unexpected 'quotedcolumnexample' in {columns}"

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1037,3 +1037,218 @@ def test_quoted_columns_preserve_case():
         assert "normal_col" in columns, f"Expected 'normal_col' in {columns}"
         # Should NOT have the lowercased version of the quoted column
         assert "quotedcolumnexample" not in columns, f"Unexpected 'quotedcolumnexample' in {columns}"
+
+
+def test_quoted_columns_end_to_end_lineage():
+    """
+    End-to-end test: verify that extract_project_lineage and build_full_lineage
+    produce correctly-cased column names for columns with quote=True.
+
+    The test creates a source with a quoted column and a model that selects from
+    it, then verifies the full lineage pipeline preserves the original casing.
+
+    Regression test for: https://github.com/b-ned/dbt-colibri/issues/102
+    """
+    from dbt_colibri.report.generator import DbtColibriReportGenerator
+
+    manifest = {
+        "metadata": {
+            "adapter_type": "snowflake",
+            "dbt_version": "1.11.6",
+            "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12.json",
+            "invocation_id": "test",
+            "project_name": "quoted_test_project"
+        },
+        "nodes": {
+            "model.quoted_test_project.my_model": {
+                "path": "models/my_model.sql",
+                "original_file_path": "models/my_model.sql",
+                "resource_type": "model",
+                "compiled_code": 'SELECT "quotedColumnExample", NORMAL_COL FROM TEST_DB.RAW.SOURCE_TABLE',
+                "raw_code": 'SELECT "quotedColumnExample", NORMAL_COL FROM {{ source("raw", "source_table") }}',
+                "depends_on": {"nodes": ["source.quoted_test_project.raw.source_table"]},
+                "database": "TEST_DB",
+                "schema": "PUBLIC",
+                "name": "my_model",
+                "alias": "my_model",
+                "columns": {
+                    "quotedColumnExample": {
+                        "name": "quotedColumnExample",
+                        "description": "A quoted column",
+                        "quote": True,
+                        "data_type": "VARCHAR",
+                        "tags": []
+                    },
+                    "NORMAL_COL": {
+                        "name": "NORMAL_COL",
+                        "description": "A normal column",
+                        "data_type": "NUMBER",
+                        "tags": []
+                    }
+                },
+                "relation_name": '"TEST_DB"."PUBLIC"."MY_MODEL"',
+                "config": {"materialized": "table"},
+                "refs": [],
+                "tags": [],
+                "fqn": ["quoted_test_project", "my_model"]
+            }
+        },
+        "sources": {
+            "source.quoted_test_project.raw.source_table": {
+                "path": "models/sources.yml",
+                "original_file_path": "models/sources.yml",
+                "resource_type": "source",
+                "database": "TEST_DB",
+                "schema": "RAW",
+                "name": "source_table",
+                "identifier": "SOURCE_TABLE",
+                "columns": {
+                    "quotedColumnExample": {
+                        "name": "quotedColumnExample",
+                        "description": "Source quoted column",
+                        "quote": True,
+                        "data_type": "VARCHAR",
+                        "tags": []
+                    },
+                    "NORMAL_COL": {
+                        "name": "NORMAL_COL",
+                        "description": "Source normal column",
+                        "data_type": "NUMBER",
+                        "tags": []
+                    }
+                },
+                "relation_name": '"TEST_DB"."RAW"."SOURCE_TABLE"',
+                "config": {"materialized": None},
+                "fqn": ["quoted_test_project", "raw", "source_table"],
+                "tags": []
+            }
+        },
+        "exposures": {},
+        "parent_map": {
+            "model.quoted_test_project.my_model": ["source.quoted_test_project.raw.source_table"],
+            "source.quoted_test_project.raw.source_table": []
+        },
+        "child_map": {
+            "source.quoted_test_project.raw.source_table": ["model.quoted_test_project.my_model"],
+            "model.quoted_test_project.my_model": []
+        }
+    }
+
+    catalog = {
+        "nodes": {
+            "model.quoted_test_project.my_model": {
+                "unique_id": "model.quoted_test_project.my_model",
+                "metadata": {
+                    "database": "TEST_DB",
+                    "schema": "PUBLIC",
+                    "name": "MY_MODEL",
+                    "type": "table"
+                },
+                "columns": {
+                    "quotedColumnExample": {
+                        "type": "VARCHAR",
+                        "name": "quotedColumnExample",
+                        "index": 1,
+                        "comment": None
+                    },
+                    "NORMAL_COL": {
+                        "type": "NUMBER",
+                        "name": "NORMAL_COL",
+                        "index": 2,
+                        "comment": None
+                    }
+                }
+            }
+        },
+        "sources": {
+            "source.quoted_test_project.raw.source_table": {
+                "unique_id": "source.quoted_test_project.raw.source_table",
+                "metadata": {
+                    "database": "TEST_DB",
+                    "schema": "RAW",
+                    "name": "SOURCE_TABLE",
+                    "type": "table"
+                },
+                "columns": {
+                    "quotedColumnExample": {
+                        "type": "VARCHAR",
+                        "name": "quotedColumnExample",
+                        "index": 1,
+                        "comment": None
+                    },
+                    "NORMAL_COL": {
+                        "type": "NUMBER",
+                        "name": "NORMAL_COL",
+                        "index": 2,
+                        "comment": None
+                    }
+                }
+            }
+        }
+    }
+
+    with patch('dbt_colibri.utils.json_utils.read_json') as mock_read_json:
+        mock_read_json.side_effect = [manifest, catalog]
+
+        extractor = DbtColumnLineageExtractor(
+            manifest_path="dummy_path",
+            catalog_path="dummy_path"
+        )
+
+        # ---- Phase 1: extract_project_lineage ----
+        result = extractor.extract_project_lineage()
+        parents = result["lineage"]["parents"]
+        children = result["lineage"]["children"]
+
+        model_id = "model.quoted_test_project.my_model"
+        source_id = "source.quoted_test_project.raw.source_table"
+
+        assert model_id in parents, f"Model not in parents map: {list(parents.keys())}"
+        model_lineage = parents[model_id]
+
+        # The quoted column key should preserve its original casing
+        assert "quotedColumnExample" in model_lineage, \
+            f"Expected 'quotedColumnExample' key in lineage, got: {list(model_lineage.keys())}"
+        assert "quotedcolumnexample" not in model_lineage, \
+            "Lowercased 'quotedcolumnexample' should NOT be a key"
+
+        # The unquoted column should be lowercased
+        assert "normal_col" in model_lineage, \
+            f"Expected 'normal_col' key in lineage, got: {list(model_lineage.keys())}"
+
+        # Verify the quoted column traces back to the source with correct case
+        quoted_parents = model_lineage["quotedColumnExample"]
+        assert len(quoted_parents) > 0, "Quoted column should have lineage parents"
+        assert quoted_parents[0]["dbt_node"] == source_id
+        assert quoted_parents[0]["column"] == "quotedColumnExample", \
+            f"Parent column should be 'quotedColumnExample', got: {quoted_parents[0]['column']}"
+
+        # Verify children map also has the correct case
+        assert source_id in children, f"Source not in children map: {list(children.keys())}"
+        source_children = children[source_id]
+        assert "quotedColumnExample" in source_children, \
+            f"Expected 'quotedColumnExample' in source children, got: {list(source_children.keys())}"
+
+        # ---- Phase 2: build_full_lineage (generator) ----
+        generator = DbtColibriReportGenerator(extractor)
+        full_lineage = generator.build_full_lineage()
+
+        # Check node columns in the output
+        model_node = full_lineage["nodes"][model_id]
+        assert "quotedColumnExample" in model_node["columns"], \
+            f"Expected 'quotedColumnExample' in output columns, got: {list(model_node['columns'].keys())}"
+        assert model_node["columns"]["quotedColumnExample"].get("quote") is True
+        assert model_node["columns"]["quotedColumnExample"].get("hasLineage") is True
+
+        assert "normal_col" in model_node["columns"], \
+            f"Expected 'normal_col' in output columns, got: {list(model_node['columns'].keys())}"
+
+        # Check that edges reference the correctly-cased column name
+        model_edges = [
+            e for e in full_lineage["lineage"]["edges"]
+            if e["target"] == model_id and e["targetColumn"] == "quotedColumnExample"
+        ]
+        assert len(model_edges) > 0, \
+            f"Expected edges targeting 'quotedColumnExample', found none. All edges: {full_lineage['lineage']['edges']}"
+        assert model_edges[0]["sourceColumn"] == "quotedColumnExample", \
+            f"Edge source column should be 'quotedColumnExample', got: {model_edges[0]['sourceColumn']}"

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -858,3 +858,92 @@ def test_column_tags_extracted_from_manifest():
     # Column without tags key should not have it
     assert "tags" not in node_data["columns"]["name"]
 
+
+def test_build_manifest_node_data_preserves_quoted_column_case():
+    """
+    Test that build_manifest_node_data preserves the original casing of columns
+    with quote=True while still lowercasing unquoted columns.
+
+    Regression test for: https://github.com/b-ned/dbt-colibri/issues/102
+    """
+    extractor = MagicMock()
+    extractor.manifest = {
+        "metadata": {"adapter_type": "snowflake"},
+        "nodes": {
+            "model.test.quoted_model": {
+                "resource_type": "model",
+                "config": {"materialized": "table"},
+                "raw_code": "select ...",
+                "compiled_code": "select ...",
+                "schema": "TEST_SCHEMA",
+                "database": "TEST_DB",
+                "original_file_path": "models/quoted_model.sql",
+                "description": "Model with quoted columns",
+                "refs": [],
+                "tags": [],
+                "relation_name": '"TEST_DB"."TEST_SCHEMA"."QUOTED_MODEL"',
+                "columns": {
+                    "quotedColumnExample": {
+                        "name": "quotedColumnExample",
+                        "description": "A quoted column",
+                        "quote": True,
+                        "data_type": "VARCHAR",
+                        "tags": []
+                    },
+                    "NORMAL_COL": {
+                        "name": "NORMAL_COL",
+                        "description": "A normal column",
+                        "data_type": "NUMBER",
+                        "tags": []
+                    }
+                },
+            }
+        },
+        "sources": {},
+        "exposures": {},
+    }
+    extractor.catalog = {
+        "nodes": {
+            "model.test.quoted_model": {
+                "unique_id": "model.test.quoted_model",
+                "metadata": {
+                    "database": "TEST_DB",
+                    "schema": "TEST_SCHEMA",
+                    "name": "QUOTED_MODEL",
+                    "type": "table"
+                },
+                "columns": {
+                    "quotedColumnExample": {
+                        "type": "VARCHAR",
+                        "name": "quotedColumnExample",
+                        "index": 1,
+                        "comment": None
+                    },
+                    "NORMAL_COL": {
+                        "type": "NUMBER",
+                        "name": "NORMAL_COL",
+                        "index": 2,
+                        "comment": None
+                    }
+                }
+            }
+        },
+        "sources": {},
+    }
+
+    generator = DbtColibriReportGenerator(extractor)
+    node_data = generator.build_manifest_node_data("model.test.quoted_model")
+
+    # Quoted column should preserve its original case
+    assert "quotedColumnExample" in node_data["columns"], \
+        f"Expected 'quotedColumnExample' in columns, got: {list(node_data['columns'].keys())}"
+    assert node_data["columns"]["quotedColumnExample"].get("quote") is True
+
+    # Unquoted column should be lowercased
+    assert "normal_col" in node_data["columns"], \
+        f"Expected 'normal_col' in columns, got: {list(node_data['columns'].keys())}"
+    assert "quote" not in node_data["columns"]["normal_col"]
+
+    # The lowercased version of the quoted column should NOT exist
+    assert "quotedcolumnexample" not in node_data["columns"]
+

--- a/uv.lock
+++ b/uv.lock
@@ -475,7 +475,7 @@ wheels = [
 
 [[package]]
 name = "dbt-colibri"
-version = "0.3.0"
+version = "0.3.1b1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
This PR fixes column lineage to preserve the original casing of columns marked with `quote: true` in the dbt manifest, while maintaining lowercase normalization for unquoted columns. This ensures that case-sensitive databases (Snowflake, Postgres, Oracle, ClickHouse) correctly track lineage for quoted identifiers.

## Key Changes

### Core Extractor Logic (`extractor.py`)
- **Added `_build_quoted_columns_lookup()`**: Builds a manifest-wide lookup of columns with `quote: true`, mapping lowercase names to their original casing. Only populated for case-sensitive quote dialects (Snowflake, Postgres, Oracle, ClickHouse).
- **Added `_resolve_column_name()`**: Resolves column names to their properly-cased form—preserving original case for quoted columns, lowercasing others. Handles SQLGlot-added double-quote wrapping.
- **Added `_get_quoted_columns()`**: Helper to retrieve the quoted columns lookup for a specific node.
- **Modified `_generate_schema_dict_from_catalog()`**: Wraps quoted column keys in double-quotes when building the schema dict, enabling SQLGlot's qualifier to match case-sensitive identifiers.
- **Added `_schema_has_quoted_keys()`**: Detects if schema contains quoted column keys to conditionally skip quote-removal during parsing.
- **Updated `_extract_lineage_for_model()`**: Uses `_resolve_column_name()` to preserve casing in lineage maps and skips quote removal when schema has quoted keys.
- **Updated `get_dbt_node_from_sqlglot_table_node()`**: Applies `_resolve_column_name()` to preserve quoted column casing during lineage resolution.
- **Extracted `_normalize_column_name()`**: Moved normalization logic to module level for reuse.

### Report Generator (`generator.py`)
- **Updated `_build_tests_by_node()`**: Uses `_resolve_column_name()` to preserve quoted column casing when building test metadata.
- **Updated `build_manifest_node_data()`**: Applies `_resolve_column_name()` to column keys in the output, ensuring quoted columns retain their original casing.

### Test Infrastructure
- **New `dbt_test_factory.py`**: Lightweight factory for generating synthetic dbt manifest + catalog pairs across all supported dialects without requiring dbt-core. Includes:
  - `DialectInfo` dataclass documenting case-sensitivity rules per dialect
  - `ColumnDef` for describing columns with quote metadata
  - `build_test_artifacts()` to generate valid manifest/catalog pairs with dialect-aware casing
  - `make_extractor()` convenience function for test setup
  - Dialect metadata for Snowflake, Postgres, Oracle, ClickHouse, BigQuery, DuckDB, Redshift, Trino, TSQL, Databricks

### Tests
- **New `test_quoted_columns_preserve_case()`**: Unit tests for `_get_quoted_columns()`, `_resolve_column_name()`, and `_get_list_of_columns_for_a_dbt_node()`.
- **New `test_quoted_columns_end_to_end_lineage()`**: End-to-end test verifying the full pipeline (extract → generate) preserves quoted column casing.
- **New `TestQuotedColumnLineageByDialect`**: Parametrized test suite covering all case-sensitive quote dialects, verifying:
  - Parents/children maps use original-case keys
  - Parent column references preserve casing
  - Report output includes correct quote flags and column names
  - Lineage edges reference correctly-cased columns
  - `find_all_related()` works with mixed-case keys
- **New `test_build_manifest_node_data_preserves_quoted_column_case()`**: Tests that the report generator preserves quoted column casing.

## Implementation Details
- The solution is dialect-aware: only case-sensitive quote dialects (Snowflake, Postgres, Oracle, ClickHouse) populate the quoted columns lookup. Case-insensitive