### PR TITLE
Fix Unknown column error on Snowflake external table metadata columns

### DIFF
--- a/src/dbt_colibri/lineage_extractor/extractor.py
+++ b/src/dbt_colibri/lineage_extractor/extractor.py
@@ -1,5 +1,6 @@
 
 from sqlglot.lineage import maybe_parse, SqlglotError, exp
+from sqlglot.schema import ensure_schema
 import logging
 from ..utils import json_utils, parsing_utils
 from .lineage import lineage, prepare_scope, extract_structural_lineage
@@ -649,6 +650,41 @@ class DbtColumnLineageExtractor:
                         return True
         return False
 
+    def _warn_unresolved_qualified_columns(self, scope, schema, model_node):
+        """Surface columns qualified to a known table but absent from the catalog.
+
+        Since ``allow_partial_qualification`` lets these flow through instead of
+        aborting the whole model (e.g. Snowflake METADATA$ pseudo-columns or a
+        stale catalog), we log them so the gap stays visible.
+        """
+        try:
+            schema_obj = ensure_schema(schema, dialect=self.dialect)
+            seen = set()
+            for sub_scope in scope.traverse():
+                for column in sub_scope.columns:
+                    table_alias = column.table
+                    if not table_alias:
+                        continue
+                    source = sub_scope.sources.get(table_alias)
+                    if not isinstance(source, exp.Table):
+                        continue
+                    known = schema_obj.column_names(source)
+                    if not known:
+                        continue
+                    if column.name.lower() in {k.lower() for k in known}:
+                        continue
+                    key = (table_alias, column.name)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    self.logger.warning(
+                        f"Column '{column.name}' in model {model_node} is qualified to "
+                        f"'{source.sql(dialect=self.dialect)}' but is not in the catalog; "
+                        f"keeping best-effort lineage."
+                    )
+        except Exception as e:
+            self.logger.debug(f"Could not check unresolved columns for {model_node}: {e}")
+
     def _extract_lineage_for_model(self, model_sql, schema, model_node, resource_type, selected_columns=[]):
         lineage_map = {}
         model_sql_for_parse = self._sanitize_sql_for_parsing(model_sql)
@@ -661,6 +697,7 @@ class DbtColumnLineageExtractor:
         if self.dialect == "bigquery":
             parsed_model_sql = parsing_utils.remove_upper(parsed_model_sql)
         qualified_expr, scope = prepare_scope(parsed_model_sql, schema=schema, dialect=self.dialect)
+        self._warn_unresolved_qualified_columns(scope, schema, model_node)
 
         for column_name in selected_columns:
             normalized_column = _normalize_column_name(column_name)
@@ -1071,6 +1108,7 @@ class DbtColumnLineageExtractor:
                 if self.dialect == "bigquery":
                     parsed_model_sql = parsing_utils.remove_upper(parsed_model_sql)
                 qualified_expr, scope = prepare_scope(parsed_model_sql, schema=schema, dialect=self.dialect)
+                self._warn_unresolved_qualified_columns(scope, schema, model_node)
 
                 # Initialize parents entry for this model
                 model_parents: dict = {}

--- a/src/dbt_colibri/lineage_extractor/lineage.py
+++ b/src/dbt_colibri/lineage_extractor/lineage.py
@@ -56,7 +56,12 @@ def prepare_scope(
         expression,
         dialect=dialect,
         schema=schema,
-        **{"validate_qualify_columns": False, "identify": False, **kwargs},  # type: ignore
+        **{
+            "validate_qualify_columns": False,
+            "identify": False,
+            "allow_partial_qualification": True,
+            **kwargs,
+        },  # type: ignore
     )
 
     scope = build_scope(expression)
@@ -109,7 +114,12 @@ def lineage(
             expression,
             dialect=dialect,
             schema=schema,
-            **{"validate_qualify_columns": False, "identify": False, **kwargs},  # type: ignore
+            **{
+                "validate_qualify_columns": False,
+                "identify": False,
+                "allow_partial_qualification": True,
+                **kwargs,
+            },  # type: ignore
         )
 
         scope = build_scope(expression)

--- a/tests/test_external_table_metadata.py
+++ b/tests/test_external_table_metadata.py
@@ -7,6 +7,7 @@ must not crash lineage extraction with "Unknown column: METADATA$FILENAME".
 
 import pytest
 import json
+import logging
 from dbt_colibri.lineage_extractor.extractor import DbtColumnLineageExtractor
 
 
@@ -151,6 +152,23 @@ def test_external_table_metadata_columns_do_not_crash(metadata_test_files):
     for meta_col in ['filename', 'file_row_number']:
         assert meta_col in model_columns, \
             f"Column {meta_col} should be present in lineage"
+
+
+def test_external_table_metadata_columns_emit_warning(metadata_test_files, caplog):
+    """A column absent from the catalog should be logged, not silently dropped."""
+    manifest_path, catalog_path = metadata_test_files
+
+    extractor = DbtColumnLineageExtractor(
+        manifest_path=manifest_path,
+        catalog_path=catalog_path
+    )
+
+    with caplog.at_level(logging.WARNING, logger="colibri"):
+        extractor.extract_project_lineage()
+
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("METADATA$FILENAME" in m and "not in the catalog" in m for m in warnings), \
+        "Expected a warning for the unresolved METADATA$FILENAME column"
 
 
 if __name__ == "__main__":

--- a/tests/test_external_table_metadata.py
+++ b/tests/test_external_table_metadata.py
@@ -1,0 +1,157 @@
+"""Tests for Snowflake external table metadata pseudo-columns (issue #122).
+
+Snowflake external tables expose METADATA$FILENAME / METADATA$FILE_ROW_NUMBER
+pseudo-columns that are not present in the dbt catalog. Models that select them
+must not crash lineage extraction with "Unknown column: METADATA$FILENAME".
+"""
+
+import pytest
+import json
+from dbt_colibri.lineage_extractor.extractor import DbtColumnLineageExtractor
+
+
+def create_metadata_test_manifest():
+    """Minimal manifest where a model selects external-table metadata columns."""
+    return {
+        "metadata": {
+            "adapter_type": "snowflake",
+            "dbt_version": "1.9.0"
+        },
+        "nodes": {
+            "model.test_project.ext_source": {
+                "unique_id": "model.test_project.ext_source",
+                "resource_type": "model",
+                "database": "TEST_DB",
+                "schema": "TEST_SCHEMA",
+                "name": "ext_source",
+                "alias": "ext_source",
+                "relation_name": "TEST_DB.TEST_SCHEMA.ext_source",
+                "columns": {"id": {}},
+                "config": {"materialized": "table"},
+                "depends_on": {"nodes": []},
+                "compiled_code": "SELECT id FROM raw_external_table",
+                "raw_code": "SELECT id FROM raw_external_table",
+                "path": "ext_source.sql"
+            },
+            "model.test_project.metadata_model": {
+                "unique_id": "model.test_project.metadata_model",
+                "resource_type": "model",
+                "database": "TEST_DB",
+                "schema": "TEST_SCHEMA",
+                "name": "metadata_model",
+                "alias": "metadata_model",
+                "relation_name": "TEST_DB.TEST_SCHEMA.metadata_model",
+                "columns": {
+                    "id": {},
+                    "filename": {},
+                    "file_row_number": {}
+                },
+                "config": {"materialized": "table"},
+                "depends_on": {"nodes": ["model.test_project.ext_source"]},
+                "compiled_code": """
+                    SELECT
+                        ext_source.id,
+                        ext_source.metadata$filename AS filename,
+                        ext_source.metadata$file_row_number AS file_row_number
+                    FROM TEST_DB.TEST_SCHEMA.ext_source AS ext_source
+                """,
+                "raw_code": """
+                    SELECT
+                        ext_source.id,
+                        ext_source.metadata$filename AS filename,
+                        ext_source.metadata$file_row_number AS file_row_number
+                    FROM {{ ref('ext_source') }} AS ext_source
+                """,
+                "path": "metadata_model.sql"
+            }
+        },
+        "sources": {},
+        "parent_map": {
+            "model.test_project.metadata_model": ["model.test_project.ext_source"],
+            "model.test_project.ext_source": []
+        },
+        "child_map": {
+            "model.test_project.ext_source": ["model.test_project.metadata_model"],
+            "model.test_project.metadata_model": []
+        }
+    }
+
+
+def create_metadata_test_catalog():
+    """Catalog deliberately omits the METADATA$ pseudo-columns, as dbt does."""
+    return {
+        "nodes": {
+            "model.test_project.ext_source": {
+                "unique_id": "model.test_project.ext_source",
+                "metadata": {
+                    "database": "TEST_DB",
+                    "schema": "TEST_SCHEMA",
+                    "name": "ext_source"
+                },
+                "columns": {"id": {"type": "NUMBER"}}
+            },
+            "model.test_project.metadata_model": {
+                "unique_id": "model.test_project.metadata_model",
+                "metadata": {
+                    "database": "TEST_DB",
+                    "schema": "TEST_SCHEMA",
+                    "name": "metadata_model"
+                },
+                "columns": {
+                    "id": {"type": "NUMBER"},
+                    "filename": {"type": "VARCHAR"},
+                    "file_row_number": {"type": "NUMBER"}
+                }
+            }
+        },
+        "sources": {}
+    }
+
+
+@pytest.fixture
+def metadata_test_files(tmp_path):
+    manifest = create_metadata_test_manifest()
+    catalog = create_metadata_test_catalog()
+
+    manifest_path = tmp_path / "manifest.json"
+    catalog_path = tmp_path / "catalog.json"
+
+    with open(manifest_path, 'w') as f:
+        json.dump(manifest, f)
+
+    with open(catalog_path, 'w') as f:
+        json.dump(catalog, f)
+
+    return str(manifest_path), str(catalog_path)
+
+
+def test_external_table_metadata_columns_do_not_crash(metadata_test_files):
+    """Selecting METADATA$ pseudo-columns should not raise 'Unknown column'."""
+    manifest_path, catalog_path = metadata_test_files
+
+    extractor = DbtColumnLineageExtractor(
+        manifest_path=manifest_path,
+        catalog_path=catalog_path
+    )
+
+    result = extractor.extract_project_lineage()
+    parents = result['lineage']['parents']
+
+    model = 'model.test_project.metadata_model'
+    assert model in parents, "metadata model should be in lineage"
+
+    model_columns = parents[model]
+
+    # The pass-through, real column still resolves to its source.
+    assert 'id' in model_columns
+    id_parents = {e['dbt_node'] for e in model_columns['id']}
+    assert 'model.test_project.ext_source' in id_parents
+
+    # The metadata pseudo-columns are present (lineage extraction did not crash).
+    for meta_col in ['filename', 'file_row_number']:
+        assert meta_col in model_columns, \
+            f"Column {meta_col} should be present in lineage"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Models referencing Snowflake external-table pseudo-columns (METADATA$FILENAME, METADATA$FILE_ROW_NUMBER) crashed lineage extraction with "Unknown column" because these columns are absent from the dbt catalog. Pass allow_partial_qualification=True to sqlglot's qualify so columns not present in the schema no longer raise during qualification.

Fixes #122