### PR TITLE
fix(fabric): normalize bracketed relation names

### DIFF
--- a/src/dbt_colibri/lineage_extractor/extractor.py
+++ b/src/dbt_colibri/lineage_extractor/extractor.py
@@ -249,7 +249,9 @@ class DbtColumnLineageExtractor:
             if node['config'].get('materialized') == 'ephemeral':
                 relation_name = node['database'] + '.' + node['schema'] + '.' + node.get('alias', node.get('name'))
             else:
-                relation_name = parsing_utils.normalize_table_relation_name(node["relation_name"])
+                relation_name = parsing_utils.normalize_table_relation_name(
+                    node["relation_name"], dialect=self.dialect
+                )
 
             # Start with manifest node info
             merged[relation_name] = {
@@ -287,7 +289,9 @@ class DbtColumnLineageExtractor:
                         (node.get("alias") or node.get("name"))
                     )
                 else:
-                    relation_name = parsing_utils.normalize_table_relation_name(node["relation_name"])
+                    relation_name = parsing_utils.normalize_table_relation_name(
+                        node["relation_name"], dialect=self.dialect
+                    )
                 if relation_name:
                     mapping[str(relation_name).lower()] = node_id
             except Exception as e:

--- a/src/dbt_colibri/utils/parsing_utils.py
+++ b/src/dbt_colibri/utils/parsing_utils.py
@@ -1,11 +1,27 @@
 import re
 from sqlglot import exp
 
-def normalize_table_relation_name(name: str) -> str:
-    # Remove surrounding quotes
+
+_TSQL_BRACKETED_IDENTIFIER = re.compile(r"\[((?:[^\]]|\]\])*)\]")
+
+
+def _unquote_tsql_identifier(match: re.Match) -> str:
+    """Remove TSQL brackets and unescape literal closing brackets."""
+    return match.group(1).replace("]]", "]")
+
+
+def normalize_table_relation_name(name: str, dialect=None) -> str:
+    """Normalize manifest relation names for matching against SQLGlot tables.
+
+    TSQL-family adapters emit bracket-quoted relation names in dbt artifacts,
+    while SQLGlot exposes the corresponding table components without brackets.
+    Only remove square-bracket quoting for those dialects so literal brackets in
+    identifiers from other dialects remain untouched.
+    """
     no_quotes = re.sub(r'"', '', name)
     no_ticks = re.sub(r'`', '', no_quotes)
-    # Lowercase for safety
+    if dialect in {"fabric", "sqlserver", "tsql"}:
+        return _TSQL_BRACKETED_IDENTIFIER.sub(_unquote_tsql_identifier, no_ticks)
     return no_ticks
 
 def remove_quotes(expression):

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -730,6 +730,65 @@ def make_extractor(manifest_nodes=None, nodes_with_columns=None):
     return extractor
 
 
+@pytest.mark.parametrize(
+    ("resource_type", "target_id"),
+    [
+        ("source", "source.test_project.bc.accounting_period"),
+        ("model", "model.test_project.stg_bc__gl_account"),
+    ],
+)
+def test_fabric_bracketed_relation_resolves_without_phantom_node(
+    resource_type, target_id
+):
+    model_node = "model.test_project.downstream"
+    target = {
+        "resource_type": resource_type,
+        "database": "Business Central Replication",
+        "schema": "dbo",
+        "name": "AccountingPeriod-50",
+        "identifier": "AccountingPeriod-50",
+        "relation_name": "[Business Central Replication].[dbo].[AccountingPeriod-50]",
+        "columns": {"No-1": {"name": "No-1"}},
+        "config": {"materialized": None if resource_type == "source" else "view"},
+    }
+    downstream = {
+        "resource_type": "model",
+        "database": "DBT Warehouse",
+        "schema": "dbt_tk",
+        "name": "downstream",
+        "alias": "downstream",
+        "relation_name": "[DBT Warehouse].[dbt_tk].[downstream]",
+        "raw_code": "select [No-1] from {{ ref_or_source() }}",
+        "columns": {},
+        "config": {"materialized": "view"},
+    }
+
+    extractor = object.__new__(DbtColumnLineageExtractor)
+    extractor.logger = logging.getLogger("colibri_test")
+    extractor.dialect = "fabric"
+    extractor.manifest = {"nodes": {model_node: downstream}, "sources": {}}
+    if resource_type == "source":
+        extractor.manifest["sources"][target_id] = target
+    else:
+        extractor.manifest["nodes"][target_id] = target
+    extractor.catalog = {"nodes": {}, "sources": {}}
+    extractor.nodes_with_columns = extractor.build_nodes_with_columns()
+    extractor._table_to_node = {
+        key.lower(): value for key, value in extractor.nodes_with_columns.items()
+    }
+
+    source = MockSource(
+        catalog="Business Central Replication",
+        db="dbo",
+        name="AccountingPeriod-50",
+    )
+    node = MockSqlglotNode(source, "AccountingPeriod-50.No-1")
+
+    result = extractor.get_dbt_node_from_sqlglot_table_node(node, model_node)
+
+    assert result == {"column": "no-1", "dbt_node": target_id}
+
+
 def test_clickhouse_leading_dot_table_matches():
     """
     Simulate ClickHouse where only db and table are used (no catalog),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,33 @@
 import json
 import os
 from collections import Counter
+import pytest
 from dbt_colibri.utils.parsing_utils import normalize_table_relation_name
+
+
+@pytest.mark.parametrize("dialect", ["fabric", "sqlserver", "tsql"])
+def test_normalize_tsql_bracketed_relation_name(dialect):
+    relation_name = "[Business Central Replication].[dbo].[AccountingPeriod-50]"
+
+    assert normalize_table_relation_name(relation_name, dialect=dialect) == (
+        "Business Central Replication.dbo.AccountingPeriod-50"
+    )
+
+
+def test_relation_normalization_preserves_literal_brackets_for_other_dialects():
+    relation_name = '"analytics"."public"."events[archived]"'
+
+    assert normalize_table_relation_name(relation_name, dialect="postgres") == (
+        "analytics.public.events[archived]"
+    )
+
+
+def test_normalize_tsql_escaped_closing_bracket():
+    relation_name = "[warehouse].[dbo].[events]]archive]"
+
+    assert normalize_table_relation_name(relation_name, dialect="fabric") == (
+        "warehouse.dbo.events]archive"
+    )
 
 
 def test_normalize_relation_name_across_sql_dialects():
@@ -122,5 +148,4 @@ def count_edges_with_double_colon(result: dict) -> dict:
         "nodes_by_type": dict(Counter(node.get("nodeType", "unknown") for node in nodes.values())),
         "hardcoded_nodes": len(hardcoded_nodes)
     }
-
 


### PR DESCRIPTION
## Summary

Normalize TSQL-style bracket-quoted relation names for Fabric and SQL Server before matching dbt manifest relations against SQLGlot tables. This prevents valid `source()` and `ref()` relations from producing duplicate `_NOT_FOUND___` and `_HARDCODED_REF___` nodes.

Fixes #134.

## Changes

- Remove TSQL square-bracket quoting when normalizing Fabric, SQL Server, and TSQL relation names.
- Unescape literal closing brackets inside bracket-quoted identifiers.
- Keep literal brackets unchanged for non-TSQL dialects.
- Add regression coverage for both source and model resolution with mixed-case names, spaces, and hyphens.

## Testing

- `pytest tests -q` — 607 passed, 13 skipped
- `ruff check src/dbt_colibri/utils/parsing_utils.py src/dbt_colibri/lineage_extractor/extractor.py tests/test_utils.py tests/test_extractor.py`
- `git diff --check`

A root-level pytest invocation additionally collects the optional performance script, which requires the separately grouped `psutil` dependency.